### PR TITLE
feat:자동 로그인 추가

### DIFF
--- a/src/api/getAccessToken.ts
+++ b/src/api/getAccessToken.ts
@@ -1,11 +1,36 @@
 import axios from 'axios';
-const getAccessToken = ({ username }: { username: string }) => {
-  const getToken = async () => {
-    const res = await axios.post('', {});
+const getAccessToken = ({
+  username,
+  email,
+  password,
+}: {
+  username: string;
+  email: string;
+  password: string;
+}) => {
+  const getLoginToken = async () => {
+    const res = await axios.post('http://34.82.77.224/login', {
+      email: email,
+      password: password,
+    });
+    console.log(res);
     return res;
   };
+  const getSignInToken = async () => {
+    const res = await axios.post('http://34.82.77.224/login/google', {
+      email,
+      name: username,
+      password,
+    });
+    if (res.status === 200) {
+      localStorage.setItem('accessToken', res.data.accessToken);
+    }
+  };
 
-  return getToken();
+  if (localStorage.getItem('accessToken') && true) {
+    return getLoginToken();
+  }
+  return getSignInToken();
 };
 
 export default getAccessToken;

--- a/src/components/Login/SignInGoogle.tsx
+++ b/src/components/Login/SignInGoogle.tsx
@@ -7,6 +7,8 @@ import { Button } from '@mui/material';
 import swal from 'sweetalert';
 import { msg, user } from '../../constants/mapConstants';
 import { useRouter } from 'next/dist/client/router';
+import getAccessToken from '../../api/getAccessToken';
+import newStore from '../Store/module';
 
 export const SigninGoogle = () => {
   const dispatch = useDispatch();
@@ -16,20 +18,25 @@ export const SigninGoogle = () => {
   const login = (email: string) => dispatch(actions.LOGINCHECK(email));
 
   const handleLogin = async () => {
+    if (newStore.getState().persist.user.email !== '') {
+      const email = newStore.getState().persist.user.email;
+      const password = 'google';
+      getAccessToken({ username: '', email, password });
+      login(email);
+      console.log('로그인');
+      return;
+    }
+
     const googleProvider = new GoogleAuthProvider();
     await signInWithPopup(auth, googleProvider)
       .then((res) => {
-        const provider = GoogleAuthProvider.credentialFromResult(res);
-        const idToken = provider?.idToken;
-
-        /*토큰 로컬 스토리지에 저장 */
-        if (typeof idToken !== 'undefined') {
-          sessionStorage.setItem('accessToken', idToken);
-          sessionStorage.setItem(user.userimgURL, res.user.photoURL as string);
-        }
-        sessionStorage.setItem('refreshToken', res.user.refreshToken);
-        if (res.user.email) {
+        if (res.user.email && res.user.displayName) {
           login(res.user.email);
+          const username = res.user.displayName;
+          const email = res.user.email;
+          const password = 'google';
+          getAccessToken({ username, email, password });
+          localStorage.setItem(user.userimgURL, res.user.photoURL as string);
         }
 
         swal(msg.loginsuccess, msg.loginsuccessBody, 'success');

--- a/src/components/Logout/SignoutGoogle.tsx
+++ b/src/components/Logout/SignoutGoogle.tsx
@@ -1,19 +1,15 @@
 import { auth } from '../../api/firebase';
 import { signOut } from 'firebase/auth';
-import { useDispatch } from 'react-redux';
-import * as actions from '../Store/module/user';
 import { useRouter } from 'next/router';
 import { Button } from '@mui/material';
+import { useDispatch } from 'react-redux';
+import * as actions from '../Store/module/user';
 
 const SignOutGoogle = () => {
   const router = useRouter();
   const dispatch = useDispatch();
   const handleSingout = async () => {
     await signOut(auth).then(() => {
-      sessionStorage.removeItem('accessToken');
-      sessionStorage.removeItem('refreshToken');
-      sessionStorage.removeItem('persist:root');
-      sessionStorage.removeItem('imgURL');
       dispatch(actions.LOGOUTCHECK());
     });
   };

--- a/src/components/Navbar/TopNav.tsx
+++ b/src/components/Navbar/TopNav.tsx
@@ -12,7 +12,7 @@ function MyAppBar() {
     return newStore.getState().persist.user.isLogin;
   };
   useEffect(() => {
-    setImg(sessionStorage.getItem(user.userimgURL));
+    setImg(localStorage.getItem(user.userimgURL));
   }, []);
 
   return (

--- a/src/components/Store/module/index.ts
+++ b/src/components/Store/module/index.ts
@@ -2,7 +2,7 @@ import { configureStore } from '@reduxjs/toolkit';
 import userSlice from './user';
 import { combineReducers } from 'redux';
 import { persistReducer } from 'redux-persist';
-import storageSession from 'redux-persist/lib/storage/session';
+import storage from 'redux-persist/lib/storage';
 
 const reducers = combineReducers({
   user: userSlice.reducer,
@@ -10,7 +10,7 @@ const reducers = combineReducers({
 
 const persistConfig = {
   key: 'root',
-  storage: storageSession,
+  storage,
   whilelist: ['user'],
 };
 

--- a/src/components/Store/module/user.ts
+++ b/src/components/Store/module/user.ts
@@ -27,7 +27,7 @@ const userSlice = createSlice({
     },
     LOGOUTCHECK(state) {
       state.isLogin = false;
-      state.email = '';
+      state.email;
     },
   },
 });


### PR DESCRIPTION
<h2>⭐  최종 로그인 과정 정리</h2>

redux-persist를 사용하였음. 다만, next js 에서 redux를 쓰는 것이 올바른 지 의문이 듬
redux를 공부하고 싶기도 했고, 사용해보고 싶어서 일단은 redux를 사용했지만
다른 상태 관리 방법 react-query,recoil등을 더 공부하고 개선해보는 것이 최종 목적임

<h3>🌟 처음 로그인 시도 시 : redux-persist의 상태에서 이메일을 가져왔을 떄 빈 문자열인 경우 </h3>

![image](https://user-images.githubusercontent.com/59411107/219819462-c9ecc589-edc7-4b69-b009-e4524dd5864c.png)

![image](https://user-images.githubusercontent.com/59411107/219819491-2eb1d102-212a-437c-a496-f759da61adc9.png)

![image](https://user-images.githubusercontent.com/59411107/219819565-559eb16a-ef67-41f4-b7b4-da50362b89a5.png)

![image](https://user-images.githubusercontent.com/59411107/219819593-65892238-0a9b-4025-aa1b-e55dd8677555.png)




⏭️ firebase를 통해 구글 로그인을 하고, 이 떄 firebase를 통한 구글 로그인이 유효하다면
⏭️ 'http://34.82.77.224/login/google'에 post요청을 보냄
⏭️ 이 떄 상태 코드가 200이라면, redux-persist로 action실행 후 토큰 저장

<h3> 🌟 처음 로그인 시도 후, 두 번쨰로 로그인 시도 시 </h3>

⏭️ redux-persist의 상태 값으로 바로 로그인을 시도함
⏭️ http://34.82.77.224/login'으로 post 요청을 보냄
⏭️ 이 떄 요청이 유효했다면(상태 코드가 200이라면) action을 실행 해서, 로그인을 한 상태임을 나타냄

<h3> 🌟 로그아웃 시 </h3>

⏭️ 로그아웃에 대한 action실행함

![image](https://user-images.githubusercontent.com/59411107/219819644-c1ea51dd-4893-4859-a620-e0213281b32c.png)



